### PR TITLE
chore: migrate references to Act Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # iam-lens
 
-[![NPM Version](https://img.shields.io/npm/v/@cloud-copilot/iam-lens.svg?logo=nodedotjs)](https://www.npmjs.com/package/@cloud-copilot/iam-lens) [![License: AGPL v3](https://img.shields.io/github/license/cloud-copilot/iam-lens)](LICENSE.txt) [![GuardDog](https://github.com/cloud-copilot/iam-lens/actions/workflows/guarddog.yml/badge.svg)](https://github.com/cloud-copilot/iam-lens/actions/workflows/guarddog.yml) [![Known Vulnerabilities](https://snyk.io/test/github/cloud-copilot/iam-lens/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/cloud-copilot/iam-lens?targetFile=package.json)
+[![NPM Version](https://img.shields.io/npm/v/@actsecurity/iam-lens.svg?logo=nodedotjs)](https://www.npmjs.com/package/@actsecurity/iam-lens) [![License: AGPL v3](https://img.shields.io/github/license/act-security-labs/iam-lens)](LICENSE.txt) [![GuardDog](https://github.com/act-security-labs/iam-lens/actions/workflows/guarddog.yml/badge.svg)](https://github.com/act-security-labs/iam-lens/actions/workflows/guarddog.yml) [![Known Vulnerabilities](https://snyk.io/test/github/act-security-labs/iam-lens/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/act-security-labs/iam-lens?targetFile=package.json)
 
-Get visibility into the IAM permissions in your AWS organizations and accounts. Use your actual AWS IAM policies (downloaded via [iam-collect](https://github.com/cloud-copilot/iam-collect)) and evaluate the effective permissions.
+Get visibility into the IAM permissions in your AWS organizations and accounts. Use your actual AWS IAM policies (downloaded via [iam-collect](https://github.com/act-security-labs/iam-collect)) and evaluate the effective permissions.
 
 ## Table of Contents
 
@@ -40,7 +40,7 @@ iam-lens who-can --resource arn:aws:s3:::example-bucket
 
 ## What is iam-lens?
 
-**iam-lens** lets you **simulate** and **audit** real IAM requests against your collected IAM data from your AWS accounts (collected via [iam-collect](https://github.com/cloud-copilot/iam-collect)) and understand the effective permissions that apply to a principal or resource.
+**iam-lens** lets you **simulate** and **audit** real IAM requests against your collected IAM data from your AWS accounts (collected via [iam-collect](https://github.com/act-security-labs/iam-collect)) and understand the effective permissions that apply to a principal or resource.
 
 ## Why use it?
 
@@ -52,7 +52,7 @@ iam-lens who-can --resource arn:aws:s3:::example-bucket
 
 ## Getting Started
 
-1. **Download Your Policies** with [iam-collect](https://github.com/cloud-copilot/iam-collect) to get all policies from your AWS accounts. iam-collect is highly configurable and can be customized to collect the policies you need. It only downloads information to your file system or an S3 bucket, so you're in full control of your data.
+1. **Download Your Policies** with [iam-collect](https://github.com/act-security-labs/iam-collect) to get all policies from your AWS accounts. iam-collect is highly configurable and can be customized to collect the policies you need. It only downloads information to your file system or an S3 bucket, so you're in full control of your data.
 
 ```bash
 npm install -g @actsecurity/iam-collect
@@ -67,7 +67,7 @@ You can download information for as many accounts, organizations, and regions as
 2. **Install iam-lens**
 
 ```bash
-npm install -g @cloud-copilot/iam-lens
+npm install -g @actsecurity/iam-lens
 ```
 
 3. **Execute Commands** with `iam-lens` to simulate requests, discover permissions, and audit your IAM policies.
@@ -196,7 +196,7 @@ iam-lens principal-can \
 
 ## Contributing & Support
 
-The best way to support is to [open an issue](https://github.com/cloud-copilot/iam-lens/issues) and let us know of any bugs, feature requests, or questions you have. We're always looking for ways to improve the project and make it more useful for everyone.
+The best way to support is to [open an issue](https://github.com/act-security-labs/iam-lens/issues) and let us know of any bugs, feature requests, or questions you have. We're always looking for ways to improve the project and make it more useful for everyone.
 
 ## Acknowledgements
 

--- a/docs/AgentInstructions.md
+++ b/docs/AgentInstructions.md
@@ -14,7 +14,7 @@ Before using iam-lens, customers MUST first collect their IAM data using `iam-co
 
 ```bash
 # Install both tools
-npm install -g @actsecurity/iam-collect @cloud-copilot/iam-lens
+npm install -g @actsecurity/iam-collect @actsecurity/iam-lens
 
 # Initialize and download IAM data (run once per account)
 iam-collect init

--- a/docs/PrincipalCan.md
+++ b/docs/PrincipalCan.md
@@ -44,7 +44,7 @@ The command returns a standard JSON policy document, such as:
 
 ### Actions List
 
-Only `Action` is included in the output. Any `NotAction` statements are converted to `Action` statements for clarity. The data for this comes from [`@actsecurity/iam-data`](https://github.com/cloud-copilot/iam-data) which is updated daily.
+Only `Action` is included in the output. Any `NotAction` statements are converted to `Action` statements for clarity. The data for this comes from [`@actsecurity/iam-data`](https://github.com/act-security-labs/iam-data) which is updated daily.
 
 All `Action`s in the output are explicit lists without wildcards. This makes it easy for any searching or automation. If you prefer shorter policies, use the `--shrink-action-lists` flag to consolidate actions using wildcards.
 

--- a/docs/Simulate.md
+++ b/docs/Simulate.md
@@ -9,7 +9,7 @@ Evaluates whether a principal can perform a specified action on a resource (or a
 Simulations can be run for any principal type (user, role, assumed role, federated user, or AWS service) and any resource type (S3 bucket, DynamoDB table, etc.). The simulation will evaluate all policies that apply to the principal and resource, including:
 
 - Identity policies (inline and managed)
-- Resource policies ([supported resource types](https://github.com/cloud-copilot/iam-collect?tab=readme-ov-file#supported-services-and-data))
+- Resource policies ([supported resource types](https://github.com/act-security-labs/iam-collect?tab=readme-ov-file#supported-services-and-data))
 - Resource Access Manager (RAM) Shares
 - Service control policies (SCPs)
 - Resource control policies (RCPs)

--- a/docs/plans/s3-bpa-simulate.md
+++ b/docs/plans/s3-bpa-simulate.md
@@ -13,7 +13,7 @@
   - Reimplement S3 BPA policy classification in `iam-lens`.
   - Change non-S3 simulation behavior.
   - Change existing S3 ABAC override behavior.
-- Target package/API: `@cloud-copilot/iam-lens`; `simulateRequest`, `whoCan` (through its existing `simulateRequest` path), and `IamCollectClient` metadata access.
+- Target package/API: `@actsecurity/iam-lens`; `simulateRequest`, `whoCan` (through its existing `simulateRequest` path), and `IamCollectClient` metadata access.
 - User-facing behavior: For S3 bucket/object requests, `iam-lens` automatically looks up S3 BPA data from the collected bucket metadata and account metadata and passes the effective setting to `iam-simulate`. Users should see simulations and who-can results that account for S3 public bucket policy restrictions when the collected metadata says `RestrictPublicBuckets` is enabled.
 - Inputs:
   - Existing `SimulationRequest` and `ResourceAccessRequest` inputs.

--- a/docs/plans/whocan-conditions.md
+++ b/docs/plans/whocan-conditions.md
@@ -5,7 +5,7 @@
 - Problem statement: `iam-simulate` now returns a structured `analysis.conditions` expression describing the conditions under which a Discovery-mode allowed request is allowed, but `iam-lens` `whoCan` still places the older `analysis.ignoredConditions` diagnostic object in the public `conditions` field.
 - Goals: For `WhoCanAllowed` and `WhoCanAllowedResourcePattern`, return the new `iam-simulate` allowed-condition expression in `conditions`, and preserve the prior ignored-condition diagnostic in a new `ignoredConditions` field.
 - Non-goals: Do not change simulation behavior, condition evaluation, deny details, CLI flags, or principal/resource discovery.
-- Target package/API: `@cloud-copilot/iam-lens` `whoCan` API and CLI JSON output; types in `src/whoCan/whoCan.ts`; mapping in `src/whoCan/WhoCanWorker.ts`.
+- Target package/API: `@actsecurity/iam-lens` `whoCan` API and CLI JSON output; types in `src/whoCan/whoCan.ts`; mapping in `src/whoCan/WhoCanWorker.ts`.
 - User-facing behavior: Allowed `whoCan` results expose `conditions` as the new structured allowed-condition expression when present and meaningful. Existing ignored discovery-condition details move to `ignoredConditions`. Unconditional allows continue to omit `conditions` rather than emitting `{ conditionType: 'always' }`.
 - Inputs: Existing `whoCan` requests and `iam-simulate` `SuccessfulRunSimulationResults`.
 - Outputs: `WhoCanAllowed.conditions?: AllowedConditionExpression`; `WhoCanAllowed.ignoredConditions?: IgnoredConditions`; same for `WhoCanAllowedResourcePattern`.
@@ -18,7 +18,7 @@
 ## Repository Reconnaissance
 
 - Current branch/status: `main...origin/main`, working tree clean at intake.
-- Package: `@cloud-copilot/iam-lens`; `@actsecurity/iam-simulate` dependency is `^0.1.163` and its declarations include `RequestAnalysis.conditions?: AllowedConditionExpression` and `RequestAnalysis.ignoredConditions?: IgnoredConditions`.
+- Package: `@actsecurity/iam-lens`; `@actsecurity/iam-simulate` dependency is `^0.1.163` and its declarations include `RequestAnalysis.conditions?: AllowedConditionExpression` and `RequestAnalysis.ignoredConditions?: IgnoredConditions`.
 - Public API entry point: `src/index.ts` exports `whoCan`, `ResourceAccessRequest`, `WhoCanAllowed`, and `WhoCanResponse`. `WhoCanAllowedResourcePattern` is exported from `src/whoCan/whoCan.ts` but not re-exported from `src/index.ts`; this change should re-export it for typed access to `allowedPatterns` entries.
 - Current mapping: `src/whoCan/WhoCanWorker.ts` maps single allowed result `analysis.ignoredConditions` into `allowed.conditions`; wildcard allowed patterns map `r.analysis.ignoredConditions` into each pattern's `conditions`.
 - Current public types: `WhoCanAllowed.conditions?: any` and `WhoCanAllowedResourcePattern.conditions?: any` with comments describing conditions under which access is allowed. No `ignoredConditions` field exists.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,7 +133,7 @@ const main = async () => {
       expectOperands: false,
       version: {
         currentVersion: iamLensVersion,
-        checkForUpdates: '@cloud-copilot/iam-lens'
+        checkForUpdates: '@actsecurity/iam-lens'
       }
     }
   )


### PR DESCRIPTION
## Summary\n- update README package, badge, and repository references to @actsecurity and act-security-labs\n- update docs and plan references from Cloud Copilot package/GitHub namespace to Act Security equivalents\n- update CLI update-check package reference to @actsecurity/iam-lens\n\n## Validation\n- npm run format\n- npm run build\n- npm test